### PR TITLE
misc: use toml config file for brew service.

### DIFF
--- a/Formula/easytier.rb
+++ b/Formula/easytier.rb
@@ -14,7 +14,7 @@ class Easytier < Formula
   end
 
   service do
-    run [opt_bin/"easytier-core", "-c", "~/.config/easytier/config.yaml"]
+    run [opt_bin/"easytier-core", "-c", "~/.config/easytier/config.toml"]
     keep_alive true
     working_dir var
     log_path var/"log/easytier.log"


### PR DESCRIPTION
Easytier uses toml as the config file now. Change the command for brew service to use a toml config file.