### PR TITLE
⬆️ easytier: 升级至 v2.4.5 版本

### DIFF
--- a/Formula/easytier.rb
+++ b/Formula/easytier.rb
@@ -1,8 +1,8 @@
 class Easytier < Formula
   desc "Simple, decentralized mesh VPN with WireGuard support"
   homepage "https://easytier.cn/"
-  url "https://github.com/EasyTier/EasyTier/archive/refs/tags/v2.4.3.tar.gz"
-  sha256 "7079522fde96ea4c1089aa89eb24bb6829f4c74dbce0ee8d3b6825cd6df3baba"
+  url "https://github.com/EasyTier/EasyTier/archive/refs/tags/v2.4.5.tar.gz"
+  sha256 "8bce53d0390bc9b2842bb863de1d4f18e6bb145fa41ec9d49683285e54423b98"
   license "Apache-2.0"
   head "https://github.com/EasyTier/EasyTier", branch: "main"
 
@@ -22,14 +22,26 @@ class Easytier < Formula
     <<~EOS
       ⚠️ EasyTier requires root privileges to create TUN/utun devices.
 
-      If your configuration uses TUN or WireGuard (e.g. includes wg:// listeners),
-      you must start the service with root privileges:
+      🚀 EasyTier 提供两种服务管理方式：
 
-          sudo brew services start easytier
+      方式一：Homebrew 服务管理（推荐入门用户）
+        sudo brew services start easytier    # 使用默认配置文件模式（~/.config/easytier/config.toml）
 
-      Note: This will change ownership of some EasyTier-related paths to root,
-      which may require manual removal using `sudo rm` during future upgrades,
-      reinstalls, or uninstalls.
+      方式二：原生服务管理（推荐高级用户）
+        # 配置文件模式
+        sudo #{opt_bin}/easytier-cli service install -c /path/to/config.toml
+
+        # 命令行参数模式（支持工作组和机器ID）
+        sudo #{opt_bin}/easytier-cli service install -w username --machine-id machine_id
+
+        # 管理原生服务
+        sudo #{opt_bin}/easytier-cli service start
+        sudo #{opt_bin}/easytier-cli service stop
+        sudo #{opt_bin}/easytier-cli service status
+
+      💡 原生服务管理支持更多高级功能和参数配置。
+
+      Note: 使用 root 权限可能需要在升级时手动清理相关文件。
     EOS
   end
 
@@ -46,5 +58,6 @@ class Easytier < Formula
     system bin/"easytier-core", "-h"
     system bin/"easytier-cli", "-h"
     system bin/"easytier-web", "-h"
+    system bin/"easytier-web-embed", "-h"
   end
 end


### PR DESCRIPTION
## 变更摘要
- 将 easytier 版本从 v2.4.3 升级至 v2.4.5
- 更新对应的 SHA256 校验和
- 增强服务管理文档说明，添加原生服务管理方式  
- 添加 easytier-web-embed 组件测试

## 测试计划
- [x] 验证新版本下载链接有效
- [x] 确认 SHA256 校验和正确
- [x] 测试安装过程正常
- [x] 验证服务启动功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)